### PR TITLE
fix: prevent AttributeError in AnalyzerAgent.run by storing agent ref…

### DIFF
--- a/src/agents/analyzer.py
+++ b/src/agents/analyzer.py
@@ -120,12 +120,10 @@ class AnalyzerAgent:
 
         Logger.debug("Running all agents")
 
-        # فقط coroutine ها رو اجرا کن
         results = await asyncio.gather(*(t[1] for t in tasks), return_exceptions=True)
 
         Logger.debug("All agents finished")
 
-        # لاگ با agent واقعی
         for i, result in enumerate(results):
             agent = tasks[i][0]
             if isinstance(result, Exception):

--- a/src/agents/analyzer.py
+++ b/src/agents/analyzer.py
@@ -57,82 +57,89 @@ class AnalyzerAgent:
             analysis_files.append(
                 self._config.repo_path / ".ai" / "docs" / "structure_analysis.md",
             )
-            tasks.append(
+            tasks.append((
+                self._structure_analyzer_agent,
                 self._run_agent(
                     agent=self._structure_analyzer_agent,
                     user_prompt=self._render_prompt("agents.structure_analyzer.user_prompt"),
                     file_path=self._config.repo_path / ".ai" / "docs" / "structure_analysis.md",
                 )
-            )
+            ))
 
         if not self._config.exclude_dependencies:
             analysis_files.append(
                 self._config.repo_path / ".ai" / "docs" / "dependency_analysis.md",
             )
-            tasks.append(
+            tasks.append((
+                self._dependency_analyzer_agent,
                 self._run_agent(
                     agent=self._dependency_analyzer_agent,
                     user_prompt=self._render_prompt("agents.dependency_analyzer.user_prompt"),
                     file_path=self._config.repo_path / ".ai" / "docs" / "dependency_analysis.md",
                 )
-            )
+            ))
 
         if not self._config.exclude_data_flow:
             analysis_files.append(
                 self._config.repo_path / ".ai" / "docs" / "data_flow_analysis.md",
             )
-            tasks.append(
+            tasks.append((
+                self._data_flow_analyzer_agent,
                 self._run_agent(
                     agent=self._data_flow_analyzer_agent,
                     user_prompt=self._render_prompt("agents.data_flow_analyzer.user_prompt"),
                     file_path=self._config.repo_path / ".ai" / "docs" / "data_flow_analysis.md",
                 )
-            )
+            ))
 
         if not self._config.exclude_request_flow:
             analysis_files.append(
                 self._config.repo_path / ".ai" / "docs" / "request_flow_analysis.md",
             )
-            tasks.append(
+            tasks.append((
+                self._request_flow_analyzer_agent,
                 self._run_agent(
                     agent=self._request_flow_analyzer_agent,
                     user_prompt=self._render_prompt("agents.request_flow_analyzer.user_prompt"),
                     file_path=self._config.repo_path / ".ai" / "docs" / "request_flow_analysis.md",
                 )
-            )
+            ))
 
         if not self._config.exclude_api_analysis:
             analysis_files.append(
                 self._config.repo_path / ".ai" / "docs" / "api_analysis.md",
             )
-            tasks.append(
+            tasks.append((
+                self._api_analyzer_agent,
                 self._run_agent(
                     agent=self._api_analyzer_agent,
                     user_prompt=self._render_prompt("agents.api_analyzer.user_prompt"),
                     file_path=self._config.repo_path / ".ai" / "docs" / "api_analysis.md",
                 )
-            )
+            ))
 
         Logger.debug("Running all agents")
 
-        # Run all agents concurrently, continue even if some fail
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # فقط coroutine ها رو اجرا کن
+        results = await asyncio.gather(*(t[1] for t in tasks), return_exceptions=True)
 
         Logger.debug("All agents finished")
 
-        # Log results for each agent
+        # لاگ با agent واقعی
         for i, result in enumerate(results):
+            agent = tasks[i][0]
             if isinstance(result, Exception):
                 Logger.error(
-                    f"Agent {tasks[i].agent.name} failed: {result}",
+                    f"Agent {agent.name} failed: {result}",
                     exc_info=True,
                 )
             else:
                 Logger.info(
-                    f"Agent {tasks[i].agent.name} completed successfully",
+                    f"Agent {agent.name} completed successfully",
                 )
 
         self.validate_succession(analysis_files)
+
 
     def validate_succession(self, analysis_files: List[Path]):
         missing_files = []


### PR DESCRIPTION
### Technical Description

The `AnalyzerAgent.run` method previously appended raw coroutines to the `tasks` list.
Later, when iterating over results, the code attempted to access `tasks[i].agent.name`. Since `tasks[i]` was just a coroutine, this caused:

```
AttributeError: 'coroutine' object has no attribute 'agent'
```

#### Fix

* Updated `tasks` to store tuples of `(agent, coroutine)` instead of only the coroutine.
* Adjusted the `asyncio.gather` call to run only the coroutine part.
* Logging now retrieves the agent reference from the tuple, ensuring proper attribution of success/failure messages.

#### Benefits

* Prevents runtime `AttributeError` in logging.
* Makes the code more explicit by always pairing an agent with its coroutine task.
* Improves reliability when multiple analyzer agents run concurrently.

---

Do you want me to also suggest a **"Test Plan"** section you can add to show maintainers how you verified the fix works?
