### PR TITLE
Fix ERROR | Agent Request Flow Analyzer failed: 'charmap' codec can't…

### DIFF
--- a/src/agents/analyzer.py
+++ b/src/agents/analyzer.py
@@ -161,7 +161,7 @@ class AnalyzerAgent:
             if not file_path.exists():
                 file_path.parent.mkdir(parents=True, exist_ok=True)
 
-            with open(file_path, "w") as f:
+            with open(file_path, "w",encoding="utf-8") as f:
                 output = self._cleanup_output(result.output)
                 f.write(output)
 


### PR DESCRIPTION
To fix the following error because the encoding are not set when the analyzer opening the file:
```
 ERROR | Agent Request Flow Analyzer failed: 'charmap' codec can't encode character '\u2192' in position 618: character maps to <undefined>
NoneType: None
```