### PR TITLE
Add Azure OpenAI Service support

### DIFF
--- a/src/agents/ai_rules_generator.py
+++ b/src/agents/ai_rules_generator.py
@@ -9,6 +9,7 @@ from pydantic_ai import Agent
 from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.providers.azure import AzureProvider
 from pydantic_ai.settings import ModelSettings
 
 import config
@@ -277,13 +278,19 @@ class AIRulesGeneratorAgent:
 
     @property
     def _markdown_llm_model(self) -> Tuple[Model, ModelSettings]:
-        model = OpenAIChatModel(
-            model_name=config.AI_RULES_LLM_MODEL,
-            provider=OpenAIProvider(
+        # Use AzureProvider if base_url is "azure", otherwise use OpenAIProvider
+        if config.AI_RULES_LLM_BASE_URL.lower() == "azure":
+            provider = AzureProvider(http_client=create_retrying_client())
+        else:
+            provider = OpenAIProvider(
                 base_url=config.AI_RULES_LLM_BASE_URL,
                 api_key=config.AI_RULES_LLM_API_KEY,
                 http_client=create_retrying_client(),
-            ),
+            )
+
+        model = OpenAIChatModel(
+            model_name=config.AI_RULES_LLM_MODEL,
+            provider=provider,
         )
 
         settings = ModelSettings(
@@ -297,13 +304,19 @@ class AIRulesGeneratorAgent:
 
     @property
     def _cursor_rules_llm_model(self) -> Tuple[Model, ModelSettings]:
-        model = OpenAIChatModel(
-            model_name=config.AI_RULES_LLM_MODEL,
-            provider=OpenAIProvider(
+        # Use AzureProvider if base_url is "azure", otherwise use OpenAIProvider
+        if config.AI_RULES_LLM_BASE_URL.lower() == "azure":
+            provider = AzureProvider(http_client=create_retrying_client())
+        else:
+            provider = OpenAIProvider(
                 base_url=config.AI_RULES_LLM_BASE_URL,
                 api_key=config.AI_RULES_LLM_API_KEY,
                 http_client=create_retrying_client(),
-            ),
+            )
+
+        model = OpenAIChatModel(
+            model_name=config.AI_RULES_LLM_MODEL,
+            provider=provider,
         )
 
         settings = ModelSettings(

--- a/src/agents/analyzer.py
+++ b/src/agents/analyzer.py
@@ -10,6 +10,7 @@ from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.providers.azure import AzureProvider
 from pydantic_ai.settings import ModelSettings
 
 import config
@@ -191,13 +192,19 @@ class AnalyzerAgent:
     def _llm_model(self) -> Tuple[Model, ModelSettings]:
         retrying_http_client = create_retrying_client()
 
-        model = OpenAIChatModel(
-            model_name=config.ANALYZER_LLM_MODEL,
-            provider=OpenAIProvider(
+        # Use AzureProvider if base_url is "azure", otherwise use OpenAIProvider
+        if config.ANALYZER_LLM_BASE_URL.lower() == "azure":
+            provider = AzureProvider(http_client=retrying_http_client)
+        else:
+            provider = OpenAIProvider(
                 base_url=config.ANALYZER_LLM_BASE_URL,
                 api_key=config.ANALYZER_LLM_API_KEY,
                 http_client=retrying_http_client,
-            ),
+            )
+
+        model = OpenAIChatModel(
+            model_name=config.ANALYZER_LLM_MODEL,
+            provider=provider,
         )
 
         settings = ModelSettings(

--- a/src/agents/documenter.py
+++ b/src/agents/documenter.py
@@ -9,6 +9,7 @@ from pydantic_ai import Agent
 from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.providers.azure import AzureProvider
 from pydantic_ai.settings import ModelSettings
 
 import config
@@ -129,13 +130,19 @@ class DocumenterAgent:
         base_url = config.DOCUMENTER_LLM_BASE_URL
         api_key = config.DOCUMENTER_LLM_API_KEY
 
-        model = OpenAIChatModel(
-            model_name=model_name,
-            provider=OpenAIProvider(
+        # Use AzureProvider if base_url is "azure", otherwise use OpenAIProvider
+        if base_url.lower() == "azure":
+            provider = AzureProvider(http_client=retrying_http_client)
+        else:
+            provider = OpenAIProvider(
                 base_url=base_url,
                 api_key=api_key,
                 http_client=retrying_http_client,
-            ),
+            )
+
+        model = OpenAIChatModel(
+            model_name=model_name,
+            provider=provider,
         )
 
         settings = ModelSettings(


### PR DESCRIPTION
## Summary

This PR adds support for Azure OpenAI Service as an alternative to the direct OpenAI API. The implementation leverages pydantic-ai's built-in `AzureProvider` which is already available in the codebase dependencies.

## Changes

Modified three files to conditionally use `AzureProvider` when `LLM_BASE_URL` is set to `"azure"`:

- `src/agents/analyzer.py`
- `src/agents/documenter.py`
- `src/agents/ai_rules_generator.py`

The pattern is identical across all agents:

```python
if config.LLM_BASE_URL.lower() == "azure":
    provider = AzureProvider(http_client=retrying_http_client)
else:
    provider = OpenAIProvider(
        base_url=config.LLM_BASE_URL,
        api_key=config.LLM_API_KEY,
        http_client=retrying_http_client,
    )
```

## Azure Configuration

When using Azure, the following environment variables are read by `AzureProvider`:

```
AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
AZURE_OPENAI_API_KEY=your-api-key
OPENAI_API_VERSION=2024-12-01-preview
```

Per-agent configuration uses `"azure"` as the base_url:

```
ANALYZER_LLM_MODEL=gpt-4o-mini  # Your deployment name
ANALYZER_LLM_BASE_URL=azure
ANALYZER_LLM_API_KEY=azure      # Ignored when using Azure
```

## Testing

Tested against Azure OpenAI Service with:
- **Deployment**: gpt-4o-mini
- **API Version**: 2024-12-01-preview (required for `tool_choice=required`)
- **Commands verified**: `analyze`, `generate readme`, `generate ai-rules`

All three commands completed successfully, generating valid output files.

## Backwards Compatibility

No breaking changes. Existing OpenAI API configurations continue to work unchanged.