### PR TITLE
[Feature] Add GitHub cronjob support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -103,7 +103,7 @@ HTTP_RETRY_MAX_TOTAL_WAIT=300           # Maximum total wait time (5 minutes)
 # - Increase timeout values (ANALYZER_LLM_TIMEOUT=300+)
 
 # ============================================================================
-# 🔗 GITLAB INTEGRATION (Required for Cronjob Mode)
+# 🔗 GITLAB INTEGRATION (Required for GitLab Cronjob Mode)
 # ============================================================================
 
 # GitLab API Configuration
@@ -117,6 +117,19 @@ GITLAB_OAUTH_TOKEN=YOUR_GITLAB_TOKEN_HERE # GitLab access token with repo permis
 # - api (full API access)
 # - read_repository (read repo contents)
 # - write_repository (create branches, commits)
+
+# ============================================================================
+# 🔗 GITHUB INTEGRATION (Required for GitHub Cronjob Mode)
+# ============================================================================
+
+# GitHub API Configuration
+GITHUB_TOKEN=YOUR_GITHUB_TOKEN_HERE     # GitHub personal access token or app token
+GITHUB_USER_NAME=AI Analyzer            # Display name for commits/PRs
+GITHUB_USER_EMAIL=YOUR_EMAIL_HERE       # Email for Git commits
+
+# 🔑 GitHub Token Permissions Required:
+# - repo (full repository access: read, write, create branches/PRs)
+# - read:org (list organization repositories)
 
 # ============================================================================
 # 📊 LOGGING & DEBUGGING

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-The AI Documentation Generator is a Python CLI tool that uses multi-agent AI to automatically analyze codebases and generate comprehensive documentation. It employs 5 specialized AI agents running concurrently to analyze code structure, dependencies, data flow, request flow, and APIs, then synthesizes results into professional README files and AI assistant configuration files (CLAUDE.md, AGENTS.md, .cursor/rules/). The system integrates with GitLab for automated project discovery and merge request creation.
+The AI Documentation Generator is a Python CLI tool that uses multi-agent AI to automatically analyze codebases and generate comprehensive documentation. It employs 5 specialized AI agents running concurrently to analyze code structure, dependencies, data flow, request flow, and APIs, then synthesizes results into professional README files and AI assistant configuration files (CLAUDE.md, AGENTS.md, .cursor/rules/). The system integrates with GitLab and GitHub for automated project discovery and pull/merge request creation.
 
 ## Common Commands
 
@@ -31,6 +31,9 @@ uv run src/main.py generate ai-rules --repo-path . --skip-existing-claude-md --s
 
 # GitLab cronjob (automated batch processing)
 uv run src/main.py cronjob analyze --max-days-since-last-commit 14
+
+# GitHub cronjob (automated batch processing for a GitHub org)
+uv run src/main.py github-cronjob analyze --org-name my-github-org --max-days-since-last-commit 14
 
 # Run with custom config
 uv run src/main.py analyze --repo-path /path/to/project --config /path/to/config.yaml
@@ -135,7 +138,8 @@ src/
 │   ├── analyze.py            # Analysis orchestration
 │   ├── readme.py             # README generation
 │   ├── ai_rules.py           # AI rules generation (CLAUDE.md, AGENTS.md, .cursor/rules/)
-│   └── cronjob.py            # GitLab automation
+│   ├── cronjob.py            # GitLab automation
+│   └── github_cronjob.py     # GitHub automation
 ├── agents/                    # AI agents
 │   ├── analyzer.py           # Multi-agent analyzer (5 concurrent agents)
 │   ├── documenter.py         # README generator
@@ -278,11 +282,22 @@ Handler Config Object
 
 ### GitLab Integration
 - **Project Filtering**: Checks archived status, subgroups, commit history, existing branches/MRs
-- **Branch Naming**: `ai-analysis-{YYYY-MM-DD}` format
+- **Branch Naming**: `ai-analyzer-{YYYY-MM-DD}` format
 - **Commit Message**: `[AI] Analyzer-Agent: Create/Update AI Analysis [skip ci]`
 - **Skip CI**: Always includes `[skip ci]` to avoid triggering pipelines
 - **Cleanup**: Guaranteed via try-finally blocks
 - **Error Isolation**: Individual project failures don't stop batch
+
+### GitHub Integration
+- **Repo Filtering**: Checks archived status, topics, commit history, existing branches/PRs
+- **Branch Naming**: `ai-analyzer-{YYYY-MM-DD}` format (same convention as GitLab)
+- **Commit Message**: `[AI] Analyzer-Agent: Create/Update AI Analysis [skip ci]`
+- **Authentication**: Personal access token or app token via `GITHUB_TOKEN` env var; token injected into HTTPS clone URL
+- **Org Scope**: Analyzes all source repos in a given GitHub org (`--org-name`)
+- **PR Creation**: Opens a pull request from the analysis branch to the repo's default branch
+- **Cleanup**: Guaranteed via try-finally blocks
+- **Error Isolation**: Individual repo failures don't stop batch
+- **Config Key**: `github_cronjob.analyze` in `.ai/config.yaml`
 
 ### Observability
 - **Langfuse Optional**: Set `ENABLE_LANGFUSE=false` to disable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-ai==1.22.0",
     "nest-asyncio==1.6.0",
     "python-gitlab==7.0.0",
+    "PyGithub==2.6.1",
     "gitpython==3.1.45",
     "logfire==4.15.1",
     "pyyaml>=6.0.2",

--- a/src/config.py
+++ b/src/config.py
@@ -73,6 +73,11 @@ GITLAB_USER_USERNAME = os.getenv("GITLAB_USER_USERNAME", "agent_doc")
 GITLAB_USER_EMAIL = os.getenv("GITLAB_USER_EMAIL")
 GITLAB_OAUTH_TOKEN = os.getenv("GITLAB_OAUTH_TOKEN")
 
+# GitHub
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+GITHUB_USER_NAME = os.getenv("GITHUB_USER_NAME", "AI Analyzer")
+GITHUB_USER_EMAIL = os.getenv("GITHUB_USER_EMAIL")
+
 # General
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 

--- a/src/handlers/github_cronjob.py
+++ b/src/handlers/github_cronjob.py
@@ -1,0 +1,203 @@
+import shutil
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List, Optional
+
+from git import Repo
+from github import Github
+from github.Repository import Repository
+from pydantic import BaseModel, Field
+
+import config
+from config import load_config_from_file
+from handlers.analyze import AnalyzeHandler, AnalyzeHandlerConfig
+from utils import Logger
+from utils.dict import merge_dicts
+
+from .base_handler import AbstractHandler
+
+COMMIT_MESSAGE_TITLE = "[AI] Analyzer-Agent: Create/Update AI Analysis"
+IGNORED_REPOS: List[str] = []  # List of repo full_names to ignore (e.g. "org/repo-name")
+IGNORED_TOPICS: List[str] = []  # List of GitHub topics to ignore
+
+
+class GithubJobAnalyzeHandlerConfig(BaseModel):
+    max_days_since_last_commit: Optional[int] = Field(
+        default=30,
+        description="Maximum days since last commit to consider a repo for cronjob execution",
+    )
+    working_path: Optional[Path] = Field(
+        default=Path("/tmp/cronjob/projects"),
+        description="Path to clone projects for cronjob execution",
+    )
+    org_name: str = Field(
+        ...,
+        description="GitHub organization name to analyze",
+    )
+
+
+class GithubJobAnalyzeHandler(AbstractHandler):
+    def __init__(self, github_client: Github, config: GithubJobAnalyzeHandlerConfig) -> None:
+        super().__init__()
+
+        self._config = config
+        self._github_client = github_client
+
+        self._config.working_path.mkdir(parents=True, exist_ok=True)
+
+    async def handle(self):
+        Logger.info(f"Starting GitHub cronjob handler for org: {self._config.org_name}")
+
+        org = self._github_client.get_organization(self._config.org_name)
+
+        for repo in org.get_repos(type="sources"):
+            try:
+                Logger.info(f"Checking repo {repo.full_name}")
+                if self._is_applicable_repo(repo):
+                    Logger.debug(f"Repo {repo.full_name} is applicable")
+                    await self._handle_repo(repo)
+            except Exception as err:
+                Logger.error(
+                    f"Error handling repo {repo.full_name}: {err}",
+                    data={"repo": repo.full_name},
+                    exc_info=True,
+                )
+
+    def _is_applicable_repo(self, repo: Repository) -> bool:
+        if repo.archived:
+            return False
+
+        if repo.full_name in IGNORED_REPOS:
+            Logger.debug(f"Repo {repo.full_name} is ignored for cronjob")
+            return False
+
+        for topic in IGNORED_TOPICS:
+            if topic in repo.get_topics():
+                return False
+
+        # Check if last commit is the AI analysis commit
+        default_branch = repo.get_branch(repo.default_branch)
+        last_commit_message = default_branch.commit.commit.message
+        if COMMIT_MESSAGE_TITLE in last_commit_message:
+            Logger.debug(f"Repo {repo.full_name} is not updated since last analysis")
+            return False
+
+        # Check if last commit is recent enough
+        last_commit_date = default_branch.commit.commit.author.date.replace(tzinfo=None)
+        days_since_last_commit = (datetime.now() - last_commit_date).days
+        if days_since_last_commit > self._config.max_days_since_last_commit:
+            Logger.debug(f"Repo {repo.full_name} last commit is {days_since_last_commit} days ago, skipping")
+            return False
+
+        # Check if today's branch already exists
+        branch_name = self._get_branch_name()
+        try:
+            repo.get_branch(branch_name)
+            Logger.debug(f"Today's branch {branch_name} already exists in {repo.full_name}")
+            return False
+        except Exception:
+            pass
+
+        # Check if a similar PR already exists
+        open_prs = repo.get_pulls(state="open")
+        for pr in open_prs:
+            if COMMIT_MESSAGE_TITLE in pr.title:
+                Logger.debug(f"Similar PR already exists in {repo.full_name}")
+                return False
+
+        return True
+
+    async def _handle_repo(self, repo: Repository):
+        Logger.info(f"Running GitHub cronjob for repo {repo.full_name}")
+        git_repo = None
+
+        try:
+            git_repo = self._clone_repo(repo)
+            await self._analyze_repo(repo=repo, git_repo=git_repo)
+            await self._create_pull_request(repo=repo, git_repo=git_repo)
+        finally:
+            if git_repo is not None:
+                self._cleanup_repo(repo=repo, git_repo=git_repo)
+
+    def _clone_repo(self, repo: Repository) -> Repo:
+        Logger.info(f"Cloning repo {repo.full_name}")
+
+        # Inject token into clone URL for authentication
+        clone_url = repo.clone_url.replace("https://", f"https://x-access-token:{config.GITHUB_TOKEN}@")
+
+        repo_dir = self._config.working_path / f"{repo.name}-{repo.id}"
+
+        if repo_dir.exists():
+            Logger.debug(f"Removing existing repo directory {repo_dir}")
+            shutil.rmtree(repo_dir, ignore_errors=True)
+
+        git_repo = Repo.clone_from(
+            url=clone_url,
+            to_path=repo_dir,
+            branch=repo.default_branch,
+        )
+
+        git_repo.git.config("user.name", config.GITHUB_USER_NAME)
+        git_repo.git.config("user.email", config.GITHUB_USER_EMAIL)
+
+        branch_name = self._get_branch_name()
+        git_repo.git.checkout("-b", branch_name)
+
+        Logger.debug(f"Cloned {repo.full_name} to branch {branch_name}")
+
+        return git_repo
+
+    async def _analyze_repo(self, repo: Repository, git_repo: Repo):
+        Logger.info(f"Analyzing repo {repo.full_name}")
+
+        args = SimpleNamespace(repo_path=git_repo.working_dir, config=None)
+        project_config = load_config_from_file(args, "analyzer")
+
+        base_config = {"repo_path": Path(git_repo.working_dir)}
+        final_config = merge_dicts(base_config, project_config)
+
+        analyzer = AnalyzeHandler(config=AnalyzeHandlerConfig(**final_config))
+        await analyzer.handle()
+
+    async def _create_pull_request(self, repo: Repository, git_repo: Repo):
+        Logger.info(f"Creating pull request for repo {repo.full_name}")
+
+        git_repo.git.add(".")
+        commit_message = f"{COMMIT_MESSAGE_TITLE} [skip ci]\n\nAnalyzer Version: {config.VERSION}"
+        git_repo.git.commit("-m", commit_message)
+        git_repo.git.push("origin", git_repo.active_branch.name, "-f")
+
+        pr = repo.create_pull(
+            title=f"{COMMIT_MESSAGE_TITLE} for {repo.name} - {datetime.now().strftime('%Y-%m-%d')} [skip ci]",
+            body=(
+                "This pull request contains updated AI analysis results.\n\n"
+                f"Analyzer Version: `{config.VERSION}`\n\n"
+                "**Note:** This pull request is automatically created by the AI Analyzer Agent."
+            ),
+            head=git_repo.active_branch.name,
+            base=repo.default_branch,
+        )
+
+        Logger.debug(
+            f"Created PR #{pr.number} for repo {repo.full_name}",
+            data={
+                "pr_number": pr.number,
+                "pr_title": pr.title,
+                "html_url": pr.html_url,
+            },
+        )
+
+    def _cleanup_repo(self, repo: Repository, git_repo: Repo):
+        Logger.info(f"Cleaning up repo {repo.full_name}")
+
+        git_repo.close()
+        git_repo.git.clear_cache()
+
+        repo_path = Path(git_repo.working_dir)
+        shutil.rmtree(repo_path, ignore_errors=True)
+
+        Logger.debug(f"Cleaned up repo {repo.full_name} at {repo_path}")
+
+    def _get_branch_name(self) -> str:
+        return f"ai-analyzer-{datetime.now().strftime('%Y-%m-%d')}"

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import logfire
 import nest_asyncio
+from github import Auth, Github
 from gitlab import Gitlab
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
@@ -20,6 +21,7 @@ from config import load_config
 from handlers.ai_rules import AIRulesHandler, AIRulesHandlerConfig
 from handlers.analyze import AnalyzeHandler, AnalyzeHandlerConfig
 from handlers.cronjob import JobAnalyzeHandler, JobAnalyzeHandlerConfig
+from handlers.github_cronjob import GithubJobAnalyzeHandler, GithubJobAnalyzeHandlerConfig
 from handlers.readme import ReadmeHandler, ReadmeHandlerConfig
 from utils import Logger
 
@@ -98,6 +100,26 @@ async def cronjob_analyze(args: argparse.Namespace):
     )
 
     handler = JobAnalyzeHandler(config=cfg, gitlab_client=gitlab_client)
+
+    await handler.handle()
+
+
+async def github_cronjob_analyze(args: argparse.Namespace):
+    cfg: GithubJobAnalyzeHandlerConfig = load_config(
+        args=args,
+        handler_config=GithubJobAnalyzeHandlerConfig,
+        file_key="github_cronjob.analyze",
+    )
+
+    configure_logging(
+        repo_path=Path("."),
+        file_level=config.FILE_LOG_LEVEL,
+        console_level=config.CONSOLE_LOG_LEVEL,
+    )
+
+    github_client = Github(auth=Auth.Token(config.GITHUB_TOKEN))
+
+    handler = GithubJobAnalyzeHandler(config=cfg, github_client=github_client)
 
     await handler.handle()
 
@@ -191,8 +213,8 @@ def parse_args():
     )
     add_handler_args(generate_ai_rules_parser, AIRulesHandlerConfig.model_fields, "AI Rules Generation Configuration")
 
-    # Cronjob command
-    cronjob_parser = subparsers.add_parser("cronjob", help="Run cronjob")
+    # Cronjob command (GitLab)
+    cronjob_parser = subparsers.add_parser("cronjob", help="Run GitLab cronjob")
     cronjob_subparsers = cronjob_parser.add_subparsers(dest="sub_command", required=True)
 
     cronjob_analyze_parser = cronjob_subparsers.add_parser("analyze", help="Run cronjob analyzer")
@@ -200,6 +222,17 @@ def parse_args():
         cronjob_analyze_parser,
         JobAnalyzeHandlerConfig.model_fields,
         "Cronjob Analyzer Configuration",
+    )
+
+    # GitHub Cronjob command
+    github_cronjob_parser = subparsers.add_parser("github-cronjob", help="Run GitHub cronjob")
+    github_cronjob_subparsers = github_cronjob_parser.add_subparsers(dest="sub_command", required=True)
+
+    github_cronjob_analyze_parser = github_cronjob_subparsers.add_parser("analyze", help="Run GitHub cronjob analyzer")
+    add_handler_args(
+        github_cronjob_analyze_parser,
+        GithubJobAnalyzeHandlerConfig.model_fields,
+        "GitHub Cronjob Analyzer Configuration",
     )
 
     return parser.parse_args()
@@ -249,6 +282,12 @@ async def main() -> Optional[int]:
                 await cronjob_analyze(args)
             else:
                 print(f"Error: Unknown cronjob sub-command '{args.sub_command}'")
+                return 1
+        case "github-cronjob":
+            if args.sub_command == "analyze":
+                await github_cronjob_analyze(args)
+            else:
+                print(f"Error: Unknown github-cronjob sub-command '{args.sub_command}'")
                 return 1
         case _:
             print(f"Error: Unknown command '{args.command}'")

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
+    { name = "pygithub" },
     { name = "python-dotenv" },
     { name = "python-gitlab" },
     { name = "pyyaml" },
@@ -47,6 +48,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-httpx", specifier = "==0.58b0" },
     { name = "pydantic", specifier = "==2.12.4" },
     { name = "pydantic-ai", specifier = "==1.22.0" },
+    { name = "pygithub", specifier = "==2.6.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "python-gitlab", specifier = "==7.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -346,6 +348,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -1593,6 +1607,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pygithub"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pynacl" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/88/e08ab18dc74b2916f48703ed1a797d57cb64eca0e23b0a9254e13cfe3911/pygithub-2.6.1.tar.gz", hash = "sha256:b5c035392991cca63959e9453286b41b54d83bf2de2daa7d7ff7e4312cebf3bf", size = 3659473, upload-time = "2025-02-21T13:45:58.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/fc/a444cd19ccc8c4946a512f3827ed0b3565c88488719d800d54a75d541c0b/PyGithub-2.6.1-py3-none-any.whl", hash = "sha256:6f2fa6d076ccae475f9fc392cc6cdbd54db985d4f69b8833a28397de75ed6ca3", size = 410451, upload-time = "2025-02-21T13:45:55.519Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1613,6 +1644,29 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `GithubJobAnalyzeHandler` (`src/handlers/github_cronjob.py`) mirroring the existing GitLab cronjob handler
- Exposes a new `github-cronjob analyze --org-name <org>` CLI command
- Adds `GITHUB_TOKEN`, `GITHUB_USER_NAME`, `GITHUB_USER_EMAIL` config vars
- Updates `.env.sample`, `CLAUDE.md`, and `pyproject.toml` (`PyGithub==2.6.1`)

## Behavior

The handler iterates all source repos in a GitHub org, filters out archived repos, repos with stale commits, and repos that already have an open analysis branch or PR, then clones, runs the analyzer, and opens a PR — identical flow to the GitLab integration.

## Test plan

- [x] `PYTHONPATH=src uv run python -c "from handlers.github_cronjob import GithubJobAnalyzeHandler"` passes
- [x] `uv run src/main.py github-cronjob analyze --help` shows correct args
- [x] End-to-end run against a GitHub org where the token has write access creates a branch and opens a PR
- [x] Re-running is a no-op (existing branch/PR detected and skipped)